### PR TITLE
Socket CORS config updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,13 @@ The networking module coordinates connections between ampm, the application its 
     // The port used to communicate between node and the client app over a TCP socket. This is
     // used for the app to send log messages and event tracking.
     "socketToAppPort": 3001,
+    
+    // CORS settings for socketToAppPort.
+    // If "localhost" (default), only allow localhost or 127.0.0.1.
+    // If null, CORS is *.
+    // Otherwise value is passed to cors options. 
+    // see https://expressjs.com/en/resources/middleware/cors.html
+    "socketToAppPortCors": "localhost",
 
     // The port used to communicate from the client app to the server over UDP/OSC.
     "oscFromAppPort": 3002,

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The persistence manager is in chage of starting a process, monitoring it, restar
     // system configuration.
     "postLaunchCommand": "",
 
-    // Restart the app if it doesn't start up in this much time. Set to
+    // Restart the app if it doesn't start up in this many seconds. Set to
     // zero (default) to allow the app to take forever to start up.
     "startupTimeout": 0,
 

--- a/model/network.cjs
+++ b/model/network.cjs
@@ -28,6 +28,12 @@ exports.Network = BaseModel.extend({
     // used for the app to send log messages and event tracking.
     socketToAppPort: 3001,
 
+    // CORS settings for socketToAppPort.
+    // If "localhost" (default), only allow localhost or 127.0.0.1.
+    // If null, CORS is *.
+    // Otherwise value is passed to cors options.
+    socketToAppPortCors: "localhost",
+
     // The port used to communicate from the client app to the server over UDP/OSC.
     oscFromAppPort: 3002,
 
@@ -174,7 +180,7 @@ exports.Network = BaseModel.extend({
     this.transports.oscFromApp.on("ready", function () {
       logger.info(
         "OSC server listening for app messages on port " +
-          this.options.localPort
+        this.options.localPort
       );
     });
 
@@ -204,12 +210,31 @@ exports.Network = BaseModel.extend({
 
     //// Set up socket connection to app.
     // Updated to use modern Socket.IO initialization API
-    this.transports.socketToApp = new Server({
-      cors: {
-        origin: "http://localhost:8000", // Allow requests from your web app's origin
+    let corsOptions = {
+      origin: "*", // Allow requests from your web app's origin
+      methods: ["GET", "POST"],
+      credentials: true, // Allow credentials to be sent
+    };
+    const corsSettings = this.get("socketToAppPortCors");
+    if (corsSettings === "localhost") {
+      // check if origin is localhost
+      corsOptions = {
+        origin: function (origin, callback) {
+          if (origin && /^https{0,1}:\/\/(localhost|127\.0\.0\.1):{0,1}\d*/.test(origin)) {
+            callback(null, true);
+          } else {
+            callback(new Error("Not allowed"), false);  
+          }
+        },
         methods: ["GET", "POST"],
         credentials: true, // Allow credentials to be sent
-      },
+      };
+    } else if (corsSettings) {
+      corsOptions = corsSettings; // use provided settings
+    }
+
+    this.transports.socketToApp = new Server({
+      cors: corsOptions,
     });
     this.transports.socketToApp.listen(this.get("socketToAppPort"));
   },


### PR DESCRIPTION
Added options to configure CORS on the socketToApp websocket. 

This allows web applications managed by ampm to be served from domains other than localhost:8000

Defaults to allowing any port on localhost or 127.0.0.1 