### PR TITLE
use tree-kill to kill the processes 

### DIFF
--- a/model/persistence.cjs
+++ b/model/persistence.cjs
@@ -10,6 +10,7 @@ var Backbone = require("backbone"); // Data model utilities. http://backbonejs.o
 var cron = require("node-cron"); // Schedule processing.
 var cronParser = require("cron-parser"); // Cron string parsing.
 var execa = require("execa"); // Modern child process execution. https://github.com/sindresorhus/execa
+var kill = require('tree-kill');
 
 var BaseModel = require("./baseModel.cjs").BaseModel;
 
@@ -296,7 +297,7 @@ exports.Persistence = BaseModel.extend({
     if (!this._lastHeart) {
       this._isStartingUp = false;
       this._firstHeart = Date.now();
-      logger.info("App started.");
+      logger.info("App started on PID " + this.processId() + ".");
 
       if (this.get("postLaunchCommand")) {
         execa
@@ -404,6 +405,7 @@ exports.Persistence = BaseModel.extend({
 
   // Kill the app process.
   shutdownApp: function (callback) {
+    logger.info("Shutting down the app with PID " + this.processId());
     if (this._isShuttingDown || this._isStartingUp) {
       return;
     }
@@ -412,6 +414,7 @@ exports.Persistence = BaseModel.extend({
 
     // See if the app is running.
     if (!this.processId() && !this.sideProcessId()) {
+      logger.info("Could not find PID running, app is already dead");
       this._isShuttingDown = false;
       // Nope, not running.
       if (callback) {
@@ -421,17 +424,18 @@ exports.Persistence = BaseModel.extend({
       return;
     }
 
-    // Kill the app.
+    // Kill the app and any child processes.
     clearTimeout(this._restartTimeout);
-    this._appProcess.kill();
+    kill(this.processId());
     if (this._sideProcess) {
-      this._sideProcess.kill();
+      kill(this.sideProcessId()); 
     }
 
     // Check on an interval to see if it's dead.
     var check = setInterval(
       _.bind(function () {
         if (this.processId() || this.sideProcessId()) {
+          // logger.info("App " + this.processId() + " is still running, check again" );
           return;
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
 				"passport-http": "^0.3.0",
 				"socket.io": "^4.7.4",
 				"socket.io-client": "^4.7.4",
+				"tree-kill": "^1.2.2",
 				"underscore.string": "^3.3.6",
 				"universal-analytics": "^0.5.3",
 				"winston": "^3.17.0",
@@ -38,10 +39,10 @@
 				"xregexp": "^5.1.1"
 			},
 			"bin": {
-				"ampm": "start.js"
+				"ampm": "start.cjs"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=22.13.1"
 			}
 		},
 		"node_modules/@babel/runtime-corejs3": {
@@ -2371,6 +2372,15 @@
 			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
 			"engines": {
 				"node": ">=0.6"
+			}
+		},
+		"node_modules/tree-kill": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+			"integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+			"license": "MIT",
+			"bin": {
+				"tree-kill": "cli.js"
 			}
 		},
 		"node_modules/triple-beam": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"passport-http": "^0.3.0",
 		"socket.io": "^4.7.4",
 		"socket.io-client": "^4.7.4",
+		"tree-kill": "^1.2.2",
 		"underscore.string": "^3.3.6",
 		"universal-analytics": "^0.5.3",
 		"winston": "^3.17.0",


### PR DESCRIPTION
Updated to use [tree-kill](https://www.npmjs.com/package/tree-kill) in the shutdown function rather than just using the app.kill() function. I noticed that sometimes the PID does not match with `tasklist` when launching an .exe which meant that on heartbeat loss AMPM would not kill the existing instance before making a new one.