### PR TITLE
allow websockets to come in from all localhost and 127.0.0.1 senders

### DIFF
--- a/model/network.cjs
+++ b/model/network.cjs
@@ -67,8 +67,8 @@ exports.Network = BaseModel.extend({
               // Invalid user.
               return done(null, false);
             }
-          }
-        )
+          },
+        ),
       );
     }
 
@@ -101,7 +101,7 @@ exports.Network = BaseModel.extend({
         secret: secret,
         resave: false,
         saveUninitialized: true,
-      })
+      }),
     );
     app.use(passport.initialize());
     app.use(passport.session());
@@ -114,7 +114,7 @@ exports.Network = BaseModel.extend({
         }),
         function (req, res) {
           res.sendFile(path.resolve(__dirname + "/../view/index.html"));
-        }
+        },
       );
     } else {
       app.get("/", function (req, res) {
@@ -174,7 +174,7 @@ exports.Network = BaseModel.extend({
     this.transports.oscFromApp.on("ready", function () {
       logger.info(
         "OSC server listening for app messages on port " +
-          this.options.localPort
+          this.options.localPort,
       );
     });
 
@@ -191,7 +191,7 @@ exports.Network = BaseModel.extend({
         } else {
           this._handleOsc(this.transports.oscFromApp, oscMessage, info);
         }
-      }, this)
+      }, this),
     );
 
     //// Set up OSC connection to app.
@@ -206,7 +206,21 @@ exports.Network = BaseModel.extend({
     // Updated to use modern Socket.IO initialization API
     this.transports.socketToApp = new Server({
       cors: {
-        origin: "http://localhost:8000", // Allow requests from your web app's origin
+        origin: (origin, callback) => {
+          // allow all local websocket communication
+          const isLocal =
+            !origin ||
+            origin.startsWith("http://localhost") ||
+            origin.startsWith("http://127.0.0.1") ||
+            origin.startsWith("https://localhost") ||
+            origin.startsWith("https://127.0.0.1");
+
+          if (isLocal) {
+            callback(null, true); // Allow the request
+          } else {
+            callback(new Error("Not allowed by CORS")); // Block external requests
+          }
+        },
         methods: ["GET", "POST"],
         credentials: true, // Allow credentials to be sent
       },

--- a/model/network.cjs
+++ b/model/network.cjs
@@ -207,13 +207,16 @@ exports.Network = BaseModel.extend({
     this.transports.socketToApp = new Server({
       cors: {
         origin: (origin, callback) => {
-          // allow all local websocket communication
-          const isLocal =
-            !origin ||
-            origin.startsWith("http://localhost") ||
-            origin.startsWith("http://127.0.0.1") ||
-            origin.startsWith("https://localhost") ||
-            origin.startsWith("https://127.0.0.1");
+          let isLocal = !origin; // No Origin header => non-browser client (.exe, TouchDesigner, etc.) — can't be forged by a browser.
+
+          if (!isLocal) {
+            try {
+              const hostname = new URL(origin).hostname;
+              isLocal = hostname === "localhost" || hostname === "127.0.0.1";
+            } catch (e) {
+              // Malformed Origin header — treat as not local.
+            }
+          }
 
           if (isLocal) {
             callback(null, true); // Allow the request


### PR DESCRIPTION
I have had issues in my web frontends with XHR polling being rejected, for example:
> Access to XMLHttpRequest at '[http://127.0.0.1:3001/socket.io/?EIO=4&transport=polling&t=qtr7isp7](https://www.google.com/url?sa=E&q=http%3A%2F%2F127.0.0.1%3A3001%2Fsocket.io%2F%3FEIO%3D4%26transport%3Dpolling%26t%3Dqtr7isp7)' from origin '[http://localhost:3000](https://www.google.com/url?sa=E&q=http%3A%2F%2Flocalhost%3A3000)' has been blocked by CORS policy: The 'Access-Control-Allow-Origin' header has a value '[http://localhost:8000](https://www.google.com/url?sa=E&q=http%3A%2F%2Flocalhost%3A8000)' that is not equal to the supplied origin.

I am able to change my server to run on port 8000, but that shouldn't be the needed change. Here I have changed the CORS policy from only allowing on localhost:8000 to allow on any localhost or 127.0.0.1 port